### PR TITLE
Inital Support for YMPD, Minor fixes

### DIFF
--- a/cmd/ipod/main.go
+++ b/cmd/ipod/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
+	"github.com/leo82309/ipod/ws"
 	"github.com/oandrew/ipod"
 	"github.com/oandrew/ipod/hid"
 	audio "github.com/oandrew/ipod/lingo-audio"
@@ -331,7 +332,7 @@ func logCmd(cmd *ipod.Command, err error, msg string) {
 
 func processFrames(frameTransport ipod.FrameReadWriter) {
 	serde := ipod.CommandSerde{}
-
+	go ws.Start()
 	for {
 		inFrame, err := frameTransport.ReadFrame()
 		if err == io.EOF {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
+	github.com/gorilla/websocket v1.5.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/urfave/cli v1.22.2
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa h1:RDBNVkRviHZtvDvId8XSGPu3rmpmSe+wKRcEWNgsfWU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/hid/report_def.go
+++ b/hid/report_def.go
@@ -46,6 +46,7 @@ var DefaultReportDefs = ReportDefs{
 	ReportDef{ID: 0x07, Len: 14, Dir: ReportDirAccIn},
 	ReportDef{ID: 0x08, Len: 20, Dir: ReportDirAccIn},
 	ReportDef{ID: 0x09, Len: 63, Dir: ReportDirAccIn},
+	ReportDef{ID: 0xAA, Len: 1024, Dir: ReportDirAccIn},
 }
 
 var LegacyReportDefs = ReportDefs{
@@ -61,6 +62,7 @@ var LegacyReportDefs = ReportDefs{
 	ReportDef{ID: 0x0A, Len: 385, Dir: ReportDirAccIn},
 	ReportDef{ID: 0x0B, Len: 513, Dir: ReportDirAccIn},
 	ReportDef{ID: 0x0C, Len: 767, Dir: ReportDirAccIn},
+	ReportDef{ID: 0xAA, Len: 1024, Dir: ReportDirAccIn},
 
 	ReportDef{ID: 0x0D, Len: 5, Dir: ReportDirAccOut},
 	ReportDef{ID: 0x0E, Len: 9, Dir: ReportDirAccOut},

--- a/lingo-extremote/handler.go
+++ b/lingo-extremote/handler.go
@@ -1,6 +1,7 @@
 package extremote
 
 import (
+	"github.com/leo82309/ipod/ws"
 	"github.com/oandrew/ipod"
 )
 
@@ -48,7 +49,7 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 		case TrackInfoCaps:
 			info = &TrackCaps{
 				Caps:         0x0,
-				TrackLength:  300 * 1000,
+				TrackLength:  uint32(ws.WSState.TotalTime * 1000),
 				ChapterCount: 1,
 			}
 		case TrackInfoDescription, TrackInfoLyrics:
@@ -86,9 +87,9 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 		ipod.Respond(req, tr, &ReturnCategorizedDatabaseRecord{})
 	case *GetPlayStatus:
 		ipod.Respond(req, tr, &ReturnPlayStatus{
-			TrackLength:   300 * 1000,
-			TrackPosition: 20 * 1000,
-			State:         PlayerStatePaused,
+			TrackLength:   uint32(ws.WSState.TotalTime * 1000),
+			TrackPosition: uint32(ws.WSState.ElapsedTime * 1000),
+			State:         PlayerStatePlaying,
 		})
 	case *GetCurrentPlayingTrackIndex:
 		ipod.Respond(req, tr, &ReturnCurrentPlayingTrackIndex{
@@ -96,15 +97,15 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 		})
 	case *GetIndexedPlayingTrackTitle:
 		ipod.Respond(req, tr, &ReturnIndexedPlayingTrackTitle{
-			Title: ipod.StringToBytes("title"),
+			Title: ipod.StringToBytes(ws.WSSongInfo.Title),
 		})
 	case *GetIndexedPlayingTrackArtistName:
 		ipod.Respond(req, tr, &ReturnIndexedPlayingTrackArtistName{
-			ArtistName: ipod.StringToBytes("artist"),
+			ArtistName: ipod.StringToBytes(ws.WSSongInfo.Artist),
 		})
 	case *GetIndexedPlayingTrackAlbumName:
 		ipod.Respond(req, tr, &ReturnIndexedPlayingTrackAlbumName{
-			AlbumName: ipod.StringToBytes("album"),
+			AlbumName: ipod.StringToBytes(ws.WSSongInfo.Album),
 		})
 	case *SetPlayStatusChangeNotification:
 		ipod.Respond(req, tr, ackSuccess(req))
@@ -136,7 +137,7 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 		})
 	case *GetNumPlayingTracks:
 		ipod.Respond(req, tr, &ReturnNumPlayingTracks{
-			NumTracks: 1,
+			NumTracks: uint32(len(ws.WSQueue)),
 		})
 	case *SetCurrentPlayingTrack:
 	case *SelectSortDBRecord:

--- a/lingo-general/handler.go
+++ b/lingo-general/handler.go
@@ -128,7 +128,7 @@ func HandleGeneral(req *ipod.Command, tr ipod.CommandWriter, dev DeviceGeneral) 
 		})
 	case *RequestLingoProtocolVersion:
 		var resp ReturnLingoProtocolVersion
-		resp.Lingo = msg.Lingo
+		resp.Lingo = 6
 		resp.Major, resp.Minor = dev.LingoProtocolVersion(msg.Lingo)
 		ipod.Respond(req, tr, &resp)
 	case *RequestTransportMaxPayloadSize:

--- a/ws/ws.go
+++ b/ws/ws.go
@@ -1,0 +1,152 @@
+package ws
+
+import (
+	"encoding/json"
+
+	log "github.com/sirupsen/logrus"
+
+	"strconv"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+type Message struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+type state_Data struct {
+	State         int `json:"state"`
+	Volume        int `json:"volume"`
+	Repeat        int `json:"repeat"`
+	Single        int `json:"single"`
+	Consume       int `json:"consume"`
+	Random        int `json:"random"`
+	SongPos       int `json:"songpos"`
+	ElapsedTime   int `json:"elapsedTime"`
+	TotalTime     int `json:"totalTime"`
+	CurrentSongID int `json:"currentsongid"`
+}
+
+type song_Data struct {
+	Position int    `json:"pos"`
+	Title    string `json:"title"`
+	Artist   string `json:"artist"`
+	Album    string `json:"album"`
+}
+type queue_Data struct {
+	ID        int    `json:"id"`
+	Position  int    `json:"pos"`
+	Durration int    `json:"duration"`
+	Title     string `json:"title"`
+}
+
+// Set the websocket address.
+var Url string = "ws://127.0.0.1"
+
+// Declare Public Variables we can use to get the current data from other classes eg. dispremote/handler.go
+var WSState = state_Data{}
+var WSQueue = []queue_Data{}
+var WSSongInfo song_Data
+
+func setWSSongInfo(songInfo song_Data) {
+	WSSongInfo = songInfo
+}
+func setWSState(stateData state_Data) {
+	WSState = stateData
+}
+func setWSQueue(queueData []queue_Data) {
+	WSQueue = queueData
+}
+
+func Start() {
+	//Creates Reading Websocket Handler and parses message based on type
+	conn, _, err := websocket.DefaultDialer.Dial(Url, nil)
+	if err != nil {
+		log.Fatal("Error connecting to WebSocket:", err)
+	}
+	defer conn.Close()
+	for {
+		// Read message from WebSocket
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			log.Println("Error reading message:", err)
+			break
+		}
+
+		// Parse message into the Message struct
+		var msg Message
+		err = json.Unmarshal(message, &msg)
+		if err != nil {
+			log.Println("Error unmarshaling message:", err)
+			continue
+		}
+
+		// Handle different message types
+		switch msg.Type {
+		case "song_change":
+			var songinfo song_Data
+			if err := json.Unmarshal(msg.Data, &songinfo); err != nil {
+				log.Println("Error decoding song change:", err)
+				continue
+			}
+			setWSSongInfo(songinfo)
+
+		case "state":
+			var statedata state_Data
+			if err := json.Unmarshal(msg.Data, &statedata); err != nil {
+				log.Println("Error decoding state:", err)
+				continue
+			}
+			setWSState(statedata)
+
+		case "queue":
+			var queuenow []queue_Data
+			if err := json.Unmarshal(msg.Data, &queuenow); err != nil {
+				log.Println("Error decoding queue:", err)
+				continue
+			}
+			setWSQueue(queuenow)
+
+		case "update_queue":
+			//ympd lets us know the queue was updated but doesn't send the updated queue to us.
+			//Write a message to get the uodated data in a "queue" message
+			err := conn.WriteMessage(websocket.TextMessage, []byte("MPD_API_GET_QUEUE,0"))
+			if err != nil {
+				log.Println("Error sending update_queue message:", err)
+			}
+
+		default:
+			log.Warn("Unsupported WS message type:", msg.Type)
+		}
+	}
+}
+
+func CommandWS(comm string) {
+	var conn = new(websocket.Conn)
+	conn, _, err := websocket.DefaultDialer.Dial(Url, nil)
+	if err != nil {
+		log.Fatal("Error connecting to WebSocket:", err)
+	}
+	defer conn.Close()
+	for {
+		// Write message to WebSocket
+		conn.WriteMessage(websocket.TextMessage, []byte(comm))
+		break
+	}
+}
+
+func NextSong() {
+	CommandWS("MPD_API_SET_NEXT")
+}
+func PrevSong() {
+	CommandWS("MPD_API_SET_PREV")
+}
+
+func SetPlayingTrack(c int32) {
+	var a = "MPD_API_PLAY_TRACK"
+	var b = c + 1
+	var d = strings.Join([]string{a, strconv.Itoa(int(b))}, ",")
+	CommandWS(d)
+}


### PR DESCRIPTION
cmd/ipod/main.go: Added async running of ws.go module
hid/report_def.go: Updated List to allow ihome dock to report data.
lingo-dispremote/handler.go: Added data handling from ws.go
lingo-extremote/handler.go: Added data handling from ws.go
lingo-general/handler.go: Fixed lingo protocol to version 6, to prevent docks from requesting iap2 versions. eg. 10+
ws/ws.go: Initial Commit, Reads websocket data from https://github.com/notandy/ympd